### PR TITLE
#68 Issue

### DIFF
--- a/mqtt-sparkplug-plus.js
+++ b/mqtt-sparkplug-plus.js
@@ -682,7 +682,7 @@ module.exports = function(RED) {
          * This method expect that the metrics attribute name exists
          */
         this.addAliasMetrics = function(msgType, metrics) {
-            let metricsCopy = metrics.map(metric => {
+            return metrics.map(metric => {
                 // Update the alias map if necessary
                 if (!node.metricsAliasMap.hasOwnProperty(metric.name)) {
                     node.metricsAliasMap[metric.name] = ++node.nextMetricAlias;
@@ -698,8 +698,7 @@ module.exports = function(RED) {
                     delete metricCopy.name;
                 }
                 return metricCopy;
-            });       
-            return metricsCopy;
+            });
         }
 
         this.getTemplates = function() {

--- a/mqtt-sparkplug-plus.js
+++ b/mqtt-sparkplug-plus.js
@@ -654,7 +654,7 @@ module.exports = function(RED) {
             };
 
             if (node.aliasMetrics) {
-                node.addAliasMetrics(msgType, msg.payload.metrics);
+                msg.payload.metrics = node.addAliasMetrics(msgType, msg.payload.metrics);
             }
             try {
                 if (node.compressAlgorithm) {
@@ -682,16 +682,24 @@ module.exports = function(RED) {
          * This method expect that the metrics attribute name exists
          */
         this.addAliasMetrics = function(msgType, metrics) {
-            metrics.forEach(metric => {
+            let metricsCopy = metrics.map(metric => {
+                // Update the alias map if necessary
                 if (!node.metricsAliasMap.hasOwnProperty(metric.name)) {
-                    node.metricsAliasMap[metric.name] = ++node.nextMetricAlias;  
+                    node.metricsAliasMap[metric.name] = ++node.nextMetricAlias;
                 }
-                var alias = node.metricsAliasMap[metric.name];
+
+                // Create a new object and copy the properties manually
+                let metricCopy = {
+                    ...metric,
+                    alias: node.metricsAliasMap[metric.name]
+                };
+                // Remove the name property if the message type is not NBIRTH or DBIRTH
                 if (msgType != "NBIRTH" && msgType != "DBIRTH") {
-                    delete metric.name;
+                    delete metricCopy.name;
                 }
-                metric.alias = alias;
-            });
+                return metricCopy;
+            });       
+            return metricsCopy;
         }
 
         this.getTemplates = function() {


### PR DESCRIPTION
I created copy of given metrics inside loop that you already do with aliases, to avoid issue that causes original metrics object to be affected by shallow copy. Reference issue [#68](url)

Although I am not sure if it was intended in first place for metrics to lose name in this process or is it just mistake that you check if metrics still have name even though aliases were already applied.

This is just suggestion that fixed issue for me, please feel free to create changes yourself and remove this PR.