### PR TITLE
#64 Issue

### DIFF
--- a/mqtt-sparkplug-plus.js
+++ b/mqtt-sparkplug-plus.js
@@ -683,7 +683,7 @@ module.exports = function(RED) {
          * This method expect that the metrics attribute name exists
          */
         this.addAliasMetrics = function(msgType, metrics) {
-            let metricsCopy = metrics.map(metric => {
+            return metrics.map(metric => {
                 // Update the alias map if necessary
                 if (!node.metricsAliasMap.hasOwnProperty(metric.name)) {
                     node.metricsAliasMap[metric.name] = ++node.nextMetricAlias;
@@ -700,8 +700,6 @@ module.exports = function(RED) {
                 }
                 return metricCopy;
             });
-        
-            return metricsCopy;
         }
 
         this.getTemplates = function() {

--- a/mqtt-sparkplug-plus.js
+++ b/mqtt-sparkplug-plus.js
@@ -654,7 +654,7 @@ module.exports = function(RED) {
             };
 
             if (node.aliasMetrics) {
-                node.addAliasMetrics(msgType, msg.payload.metrics);
+                msg.payload.metrics = node.addAliasMetrics(msgType, msg.payload.metrics);
             }
             try {
                 if (node.compressAlgorithm) {
@@ -682,16 +682,25 @@ module.exports = function(RED) {
          * This method expect that the metrics attribute name exists
          */
         this.addAliasMetrics = function(msgType, metrics) {
-            metrics.forEach(metric => {
+            let metricsCopy = metrics.map(metric => {
+                // Update the alias map if necessary
                 if (!node.metricsAliasMap.hasOwnProperty(metric.name)) {
-                    node.metricsAliasMap[metric.name] = ++node.nextMetricAlias;  
+                    node.metricsAliasMap[metric.name] = ++node.nextMetricAlias;
                 }
-                var alias = node.metricsAliasMap[metric.name];
+
+                // Create a new object and copy the properties manually
+                let metricCopy = {
+                    ...metric,
+                    alias: node.metricsAliasMap[metric.name]
+                };
+                // Remove the name property if the message type is not NBIRTH or DBIRTH
                 if (msgType != "NBIRTH" && msgType != "DBIRTH") {
-                    delete metric.name;
+                    delete metricCopy.name;
                 }
-                metric.alias = alias;
+                return metricCopy;
             });
+        
+            return metricsCopy;
         }
 
         this.getTemplates = function() {

--- a/mqtt-sparkplug-plus.js
+++ b/mqtt-sparkplug-plus.js
@@ -25,6 +25,7 @@ module.exports = function(RED) {
     var long = require("long");
     var pako = require('pako');
     var compressed = "SPBV1.0_COMPRESSED";
+    var certTypes = ["NBIRTH", "NDEATH", "DBIRTH", "DDEATH"];
 
     /**
      * Try to decompress the payload if if compressed uuid is set on the payload
@@ -694,7 +695,7 @@ module.exports = function(RED) {
                     alias: node.metricsAliasMap[metric.name]
                 };
                 // Remove the name property if the message type is not NBIRTH or DBIRTH
-                if (msgType != "NBIRTH" && msgType != "DBIRTH") {
+                if (!certTypes.includes(msgType)) {
                     delete metricCopy.name;
                 }
                 return metricCopy;


### PR DESCRIPTION
In this PR I just extended your check for cert types where you skipped deleting metric.name. I added NDEATH and DDEATH.
I created certTypes array globally to avoid creating it every time loop runs. 

So instead of skipping NDEATH and DDEATH types when creating alias, I just included them in that check to skip deleting metric.name. 
Let me know if that is fine and if we still need to check with Sparkplug spec.