### PR TITLE
Run the Sparkplug TCK headlessly in CI

### DIFF
--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -1,0 +1,92 @@
+name: Sparkplug TCK
+
+# Runs the Eclipse Sparkplug TCK (Edge Node profile) against the nodes in this
+# repo. The TCK is normally driven from a Nuxt web console, but its control
+# plane is plain MQTT, so test/tck/run-tck.js drives it headlessly.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  # Pinned: the TCK's utility clients hardcode tcp://localhost:1883, so the
+  # broker must own that port. Nothing else in this workflow binds it.
+  SPARKPLUG_REF: v3.0.0
+  HIVEMQ_VERSION: '2024.9'
+
+jobs:
+  tck:
+    name: Edge Node profile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Checkout Sparkplug TCK
+        uses: actions/checkout@v4
+        with:
+          repository: eclipse-sparkplug/sparkplug
+          ref: ${{ env.SPARKPLUG_REF }}
+          path: sparkplug-tck
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: temurin
+          cache: gradle
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Cache HiveMQ download
+        uses: actions/cache@v4
+        with:
+          path: .tck-broker/cache
+          key: hivemq-ce-${{ env.HIVEMQ_VERSION }}
+
+      # The tck/ directory ships a gradlew without its wrapper jar, so the root
+      # wrapper with -p tck is the only way to build it.
+      - name: Build TCK HiveMQ extension
+        run: ./gradlew -p tck hivemqExtensionZip --no-daemon
+        working-directory: sparkplug-tck
+
+      - name: Start broker with TCK extension
+        run: |
+          nohup test/tck/start-broker.sh sparkplug-tck > hivemq.log 2>&1 &
+          echo "Waiting for broker on 1883..."
+          for i in $(seq 1 90); do
+            if grep -q "Started TCP Listener" hivemq.log 2>/dev/null; then
+              echo "Broker is up."
+              exit 0
+            fi
+            if grep -q "Could not bind any listener\|Shutdown completed" hivemq.log 2>/dev/null; then
+              echo "Broker failed to start:"; cat hivemq.log; exit 1
+            fi
+            sleep 2
+          done
+          echo "Broker did not start in time:"; cat hivemq.log; exit 1
+
+      - name: Run Sparkplug TCK
+        run: node test/tck/run-tck.js
+        env:
+          TCK_BROKER: mqtt://localhost:1883
+          TCK_VERBOSE: '1'
+
+      - name: Upload TCK results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tck-results
+          path: |
+            tck-results.json
+            hivemq.log
+            .tck-broker/hivemq-ce-*/bin/SparkplugTCKResults.log
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,12 @@ dist
 .pnp.*
 package-lock.json
 .mqtt-sparkplug.js.swp
+.DS_Store
+
+# Local clone of the Eclipse Sparkplug spec/TCK used as reference.
+# CI checks this out itself at a pinned tag (see .github/workflows/tck.yml).
+ref/
+
+# TCK harness output
+tck-results.json
+.tck-broker/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   },
   "scripts": {
     "test": "mocha --exit \"test/**/*_spec.js\"",
-    "coverage": "nyc --reporter=lcov --reporter=text mocha --exit \"test/**/*_spec.js\""
+    "coverage": "nyc --reporter=lcov --reporter=text mocha --exit \"test/**/*_spec.js\"",
+    "tck": "node test/tck/run-tck.js",
+    "tck:broker": "test/tck/start-broker.sh"
   },
   "keywords": [
     "MQTT",

--- a/test/tck/README.md
+++ b/test/tck/README.md
@@ -1,0 +1,95 @@
+# Sparkplug TCK harness
+
+Runs the [Eclipse Sparkplug TCK](https://github.com/eclipse-sparkplug/sparkplug)
+(Edge Node profile) against the nodes in this repo, unattended.
+
+The TCK is documented as a manual process driven from a Nuxt web console. It
+doesn't have to be: the console is only an MQTT client, and the TCK's whole
+control plane is plain MQTT topics (`SPARKPLUG_TCK/TEST_CONTROL`,
+`SPARKPLUG_TCK/RESULT`, `SPARKPLUG_TCK/LOG`). `run-tck.js` speaks that protocol
+directly and drives the nodes in-process with `node-red-node-test-helper`.
+
+None of the Edge Node tests call the TCK's `prompt()` - only the Host profile
+tests do - and the TCK brings its own simulated Host Application online, so
+there is nothing for a human to do.
+
+| File | Purpose |
+|---|---|
+| `run-tck.js` | the harness - drives the TCK and the nodes, exits non-zero on failure |
+| `tck-flow.js` | parameterized Node-RED flow fixture |
+| `start-broker.sh` | downloads HiveMQ, installs the TCK extension, runs it |
+| `hivemq-config.xml` | broker config (TCP listener only, usage stats off) |
+
+## Running locally
+
+```bash
+# 1. Clone the spec/TCK repo (once). CI does this itself at a pinned tag.
+git clone --branch v3.0.0 https://github.com/eclipse-sparkplug/sparkplug.git ref/sparkplug
+
+# 2. Build the TCK HiveMQ extension (once, ~1 min).
+#    Note: tck/ ships a gradlew *without* its wrapper jar, so use the root
+#    wrapper with -p tck.
+(cd ref/sparkplug && ./gradlew -p tck hivemqExtensionZip)
+
+# 3. Start the broker (terminal 1). Wait for "Started TCP Listener".
+npm run tck:broker
+
+# 4. Run the tests (terminal 2).
+npm run tck                        # all five
+npm run tck ReceiveCommandTest     # or just one
+```
+
+Useful env vars: `TCK_BROKER`, `TCK_VERBOSE=1`, `TCK_TEST_TIMEOUT_MS`,
+`TCK_HOST_APP_ID`, `TCK_GROUP_ID`.
+
+## Things that will bite you
+
+**The broker must be on port 1883.** Not configurable. The TCK's internal
+utility clients - the simulated Host Application and Edge Node it uses to drive
+tests - construct `new HostApplication()`, which hardcodes
+`tcp://localhost:1883` (`TCK.java:53`, `HostApplication.java:50`). There is no
+system property or config for it. If something else owns 1883 (a mosquitto
+container, say), the TCK will happily publish STATE to *that* broker instead and
+every test will hang waiting for a birth that never comes.
+
+`start-broker.sh` accepts `HIVEMQ_PORT` for convenience, but anything other than
+1883 only works for tests that never need the simulated host - which is none of
+them.
+
+**Restart the broker between full runs.** The TCK's `Monitor` keeps a
+per-edge-node `bdSeq` map for the lifetime of the broker process and only clears
+`testResults` between tests, never that map. A second run of the same test would
+see the node restart at bdSeq 0 and report a spurious
+`topics-nbirth-bdseq-increment` failure. The harness already gives each test its
+own edge node ID for this reason, but that only helps within one broker session.
+
+**HiveMQ CE 2021.1 does not run on Apple Silicon.** The TCK's own
+`runHivemqWithExtension` Gradle task pins it, and its bundled JNA has no arm64
+native library (`UnsatisfiedLinkError` from `MacCentralProcessor`).
+`start-broker.sh` uses a current HiveMQ CE instead, which runs on both
+architectures.
+
+**`payloads-dbirth-timestamp` / `topics-dbirth-timestamp` are timing-flaky on
+loopback.** The TCK requires `payloadTimestamp < messageReceivedTime`, strictly
+(`SessionEstablishmentTest.java:886`). The node stamps the payload and publishes
+microseconds later, so over localhost the two land in the same millisecond often
+enough that this assertion flips between runs. It is a TCK strictness artifact,
+not a defect in the node. If CI proves noisy, re-run before investigating.
+
+## What counts as a pass
+
+The TCK appends `but INCOMPLETE` to its `OVERALL` line whenever a non-Monitor
+assertion is `NOT EXECUTED`. Some assertions cannot apply to this node at all -
+the MQTT 5.0 session variant (the node uses 3.1.1), metric aliases, and the
+optional templates group - so `PASS but INCOMPLETE` is the best achievable
+result for this configuration.
+
+The harness therefore does not key off `OVERALL` alone. It accepts a test when
+`OVERALL` starts with `PASS`, no assertion failed, and every `NOT EXECUTED`
+assertion is in the `EXPECTED_NOT_EXECUTED` allowlist in `run-tck.js` (each
+entry carries the reason). Anything unexecuted for a reason not on that list
+fails the run, so new coverage gaps stay visible instead of hiding behind
+"INCOMPLETE".
+
+Full per-assertion output is written to `tck-results.json`, and the TCK's own
+log ends up in `.tck-broker/hivemq-ce-*/bin/SparkplugTCKResults.log`.

--- a/test/tck/hivemq-config.xml
+++ b/test/tck/hivemq-config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+  HiveMQ configuration used when running the Sparkplug TCK.
+
+  Based on ref/sparkplug/tck/hivemq-configuration/config.xml, with two changes:
+    * only the TCP listener is kept - the websocket listener exists purely for
+      the Nuxt web console, which the headless harness replaces
+    * anonymous usage statistics are disabled so CI makes no outbound call
+-->
+<hivemq>
+
+    <listeners>
+        <tcp-listener>
+            <port>1883</port>
+            <bind-address>0.0.0.0</bind-address>
+        </tcp-listener>
+    </listeners>
+
+    <anonymous-usage-statistics>
+        <enabled>false</enabled>
+    </anonymous-usage-statistics>
+
+</hivemq>

--- a/test/tck/run-tck.js
+++ b/test/tck/run-tck.js
@@ -1,0 +1,477 @@
+/**
+ * Headless runner for the Eclipse Sparkplug TCK, Edge Node profile.
+ *
+ * The TCK ships a Nuxt web console, which makes it look like a manual process.
+ * It isn't: the console is just an MQTT client, and the whole control plane is
+ * plain MQTT topics (see Constants.java in the TCK source). This script speaks
+ * that protocol directly and drives the Node-RED nodes under test in-process
+ * via node-red-node-test-helper, so the whole thing runs unattended in CI.
+ *
+ * None of the Edge Node tests call the TCK's prompt() - only the Host profile
+ * tests do - so no operator interaction is needed. The TCK also brings its own
+ * simulated Host Application online, so there is nothing external to
+ * orchestrate.
+ *
+ * Usage:  node test/tck/run-tck.js [testName ...]
+ * Exits non-zero if any test does not report OVERALL: PASS.
+ */
+
+const mqtt = require("mqtt");
+const path = require("path");
+const fs = require("fs");
+const helper = require("node-red-node-test-helper");
+const sparkplugNode = require("../../mqtt-sparkplug-plus.js");
+const { buildFlow } = require("./tck-flow");
+
+helper.init(require.resolve("node-red"));
+
+// ── TCK control plane (tck/.../test/common/Constants.java) ───────────────────
+const TCK_TEST_CONTROL = "SPARKPLUG_TCK/TEST_CONTROL";
+const TCK_RESULT = "SPARKPLUG_TCK/RESULT";
+const TCK_LOG = "SPARKPLUG_TCK/LOG";
+
+const BROKER_URL = process.env.TCK_BROKER || "mqtt://localhost:1883";
+const HOST_APP_ID = process.env.TCK_HOST_APP_ID || "SparkplugTCKHost";
+const GROUP_ID = process.env.TCK_GROUP_ID || "SparkplugTCKGroup";
+const EDGE_NODE_ID = process.env.TCK_EDGE_NODE_ID || "NodeRedEdgeNode";
+const DEVICE_ID = process.env.TCK_DEVICE_ID || "NodeRedDevice";
+
+const TEST_TIMEOUT_MS = Number(process.env.TCK_TEST_TIMEOUT_MS || 90000);
+const BIRTH_TIMEOUT_MS = Number(process.env.TCK_BIRTH_TIMEOUT_MS || 20000);
+const RESULTS_FILE = process.env.TCK_RESULTS_FILE || "tck-results.json";
+
+const brokerUrl = new URL(BROKER_URL.replace(/^mqtt(s?)/, "http$1"));
+const BROKER_HOST = brokerUrl.hostname;
+const BROKER_PORT = brokerUrl.port || "1883";
+
+// The two metrics the device is born with. Every configured metric must have a
+// value before this node publishes DBIRTH (see trySendBirth in
+// mqtt-sparkplug-plus.js), so the harness has to feed them.
+const DEVICE_METRICS = {
+	"test/int": { dataType: "Int32" },
+	"test/bool": { dataType: "Boolean" }
+};
+
+const initialMetricValues = () => [
+	{ name: "test/int", value: 1, type: "Int32", timestamp: Date.now() },
+	{ name: "test/bool", value: true, type: "Boolean", timestamp: Date.now() }
+];
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ── Node-RED lifecycle ──────────────────────────────────────────────────────
+
+function loadFlow(edgeNodeId, flowOpts) {
+	const flow = buildFlow(
+		Object.assign(
+			{
+				groupId: GROUP_ID,
+				edgeNodeId: edgeNodeId,
+				deviceId: DEVICE_ID,
+				brokerHost: BROKER_HOST,
+				brokerPort: BROKER_PORT,
+				metrics: DEVICE_METRICS,
+				// Every edge test brings the simulated Host Application online and
+				// asserts tck-id-message-flow-edge-node-birth-publish-phid-wait:
+				// the node MUST wait for STATE before NBIRTH. So the node under
+				// test is always configured with a Primary Host.
+				primaryScada: HOST_APP_ID
+			},
+			flowOpts
+		)
+	);
+	return new Promise((resolve) => helper.load(sparkplugNode, flow, {}, resolve));
+}
+
+async function unloadFlow() {
+	await helper.unload();
+	// Give the broker a moment to process the resulting DISCONNECT/NDEATH before
+	// the next test starts observing.
+	await sleep(500);
+}
+
+/** Feed every configured metric so the device reaches its DBIRTH condition. */
+function sendInitialMetricValues() {
+	helper.getNode("device").receive({ payload: { metrics: initialMetricValues() } });
+}
+
+// ── Sparkplug observer ──────────────────────────────────────────────────────
+
+/**
+ * A passive MQTT client used to tell when the node under test has birthed, so
+ * the harness can sequence its actions instead of guessing with sleeps.
+ */
+class Observer {
+	constructor(client) {
+		this.client = client;
+		this.seen = new Set();
+		this.waiters = [];
+		client.on("message", (topic) => {
+			this.seen.add(topic);
+			this.waiters = this.waiters.filter((w) => {
+				if (topic.startsWith(w.prefix)) {
+					w.resolve(topic);
+					return false;
+				}
+				return true;
+			});
+		});
+	}
+
+	static async connect() {
+		const client = mqtt.connect(BROKER_URL, { clientId: `tck-observer-${Date.now()}` });
+		await new Promise((resolve, reject) => {
+			client.once("connect", resolve);
+			client.once("error", reject);
+		});
+		await new Promise((resolve, reject) =>
+			client.subscribe("spBv1.0/#", { qos: 0 }, (err) => (err ? reject(err) : resolve()))
+		);
+		return new Observer(client);
+	}
+
+	reset() {
+		this.seen.clear();
+	}
+
+	/** Resolve when a topic starting with `prefix` arrives (or already has). */
+	wait(prefix, timeoutMs, label) {
+		for (const topic of this.seen) {
+			if (topic.startsWith(prefix)) return Promise.resolve(topic);
+		}
+		return new Promise((resolve, reject) => {
+			const waiter = { prefix, resolve };
+			this.waiters.push(waiter);
+			setTimeout(() => {
+				this.waiters = this.waiters.filter((w) => w !== waiter);
+				reject(new Error(`timed out after ${timeoutMs}ms waiting for ${label || prefix}`));
+			}, timeoutMs);
+		});
+	}
+
+	waitForNBirth(edgeNodeId) {
+		return this.wait(`spBv1.0/${GROUP_ID}/NBIRTH/${edgeNodeId}`, BIRTH_TIMEOUT_MS, "NBIRTH");
+	}
+
+	waitForDBirth(edgeNodeId) {
+		return this.wait(
+			`spBv1.0/${GROUP_ID}/DBIRTH/${edgeNodeId}/${DEVICE_ID}`,
+			BIRTH_TIMEOUT_MS,
+			"DBIRTH"
+		);
+	}
+
+	end() {
+		this.client.end(true);
+	}
+}
+
+/** Load the flow and drive it all the way to NBIRTH + DBIRTH. */
+async function birth(observer, edgeNodeId, flowOpts) {
+	await loadFlow(edgeNodeId, flowOpts);
+	await observer.waitForNBirth(edgeNodeId);
+	sendInitialMetricValues();
+	await observer.waitForDBirth(edgeNodeId);
+}
+
+// ── TCK control client ──────────────────────────────────────────────────────
+
+class TckControl {
+	constructor(client) {
+		this.client = client;
+		this.resultWaiter = null;
+		this.logs = [];
+		client.on("message", (topic, payload) => {
+			const text = payload.toString();
+			if (topic === TCK_LOG) {
+				this.logs.push(text);
+				if (process.env.TCK_VERBOSE) console.log(`  [tck] ${text}`);
+			} else if (topic === TCK_RESULT) {
+				if (this.resultWaiter) {
+					const waiter = this.resultWaiter;
+					this.resultWaiter = null;
+					waiter(text);
+				}
+			}
+		});
+	}
+
+	static async connect() {
+		const client = mqtt.connect(BROKER_URL, { clientId: `tck-harness-${Date.now()}` });
+		await new Promise((resolve, reject) => {
+			client.once("connect", resolve);
+			client.once("error", reject);
+		});
+		await new Promise((resolve, reject) =>
+			client.subscribe([TCK_RESULT, TCK_LOG], { qos: 2 }, (err) => (err ? reject(err) : resolve()))
+		);
+		return new TckControl(client);
+	}
+
+	/** Arm the result listener *before* the test starts, to avoid a race. */
+	expectResult() {
+		return new Promise((resolve) => {
+			this.resultWaiter = resolve;
+		});
+	}
+
+	publish(topic, message) {
+		return new Promise((resolve, reject) =>
+			this.client.publish(topic, message, { qos: 2 }, (err) => (err ? reject(err) : resolve()))
+		);
+	}
+
+	startTest(testName, params) {
+		this.logs = [];
+		const cmd = `NEW_TEST EDGE ${testName} ${params.join(" ")}`;
+		console.log(`  -> ${cmd}`);
+		return this.publish(TCK_TEST_CONTROL, cmd);
+	}
+
+	endTest() {
+		return this.publish(TCK_TEST_CONTROL, "END_TEST");
+	}
+
+	end() {
+		this.client.end(true);
+	}
+}
+
+// ── Test definitions ────────────────────────────────────────────────────────
+
+const TESTS = [
+	{
+		name: "SessionEstablishmentTest",
+		// The TCK must observe the CONNECT itself, so the flow is loaded only
+		// after the test is armed.
+		async run({ observer, edgeNodeId }) {
+			await birth(observer, edgeNodeId);
+		}
+	},
+	{
+		name: "SessionTerminationTest",
+		async run({ observer, edgeNodeId }) {
+			await birth(observer, edgeNodeId);
+			// Unloading closes the nodes, which disconnects the client and
+			// produces the DDEATH/NDEATH the test looks for.
+			await unloadFlow();
+		}
+	},
+	{
+		name: "SendDataTest",
+		async run({ observer, edgeNodeId }) {
+			await birth(observer, edgeNodeId);
+
+			// DDATA - a value change on an already-born device.
+			helper.getNode("device").receive({
+				payload: { metrics: [{ name: "test/int", value: 42, type: "Int32", timestamp: Date.now() }] }
+			});
+
+			// NDATA - via the generic out node, which publishes whatever topic
+			// and payload it is handed.
+			await sleep(500);
+			helper.getNode("out").receive({
+				topic: `spBv1.0/${GROUP_ID}/NDATA/${edgeNodeId}`,
+				payload: {
+					timestamp: Date.now(),
+					metrics: [{ name: "test/int", value: 43, type: "Int32", timestamp: Date.now() }],
+					seq: 1
+				}
+			});
+		}
+	},
+	{
+		name: "ReceiveCommandTest",
+		// The TCK sends NCMD rebirth / DCMD and watches the response, so the
+		// flow just needs to stay up.
+		async run({ observer, edgeNodeId }) {
+			await birth(observer, edgeNodeId);
+		}
+	},
+	{
+		name: "PrimaryHostTest",
+		// This test drives the simulated host online/offline itself and checks
+		// the node births only for the correct host being ONLINE. The node must
+		// therefore already be connected and waiting on STATE when it starts.
+		loadBeforeStart: true,
+		async run({ edgeNodeId }) {
+			// Values are queued while offline and flushed when the correct host
+			// goes ONLINE, so NBIRTH and DBIRTH both follow the STATE message.
+			sendInitialMetricValues();
+		}
+	}
+];
+
+// ── Result interpretation ───────────────────────────────────────────────────
+//
+// The TCK appends "but INCOMPLETE" to OVERALL whenever any non-Monitor
+// assertion is NOT EXECUTED. Some assertions cannot apply to this node at all,
+// so INCOMPLETE on its own is not a failure - but an assertion going
+// unexecuted for any *other* reason is a coverage gap we do want to see. Hence
+// the allowlist: anything not in it makes the run fail.
+const EXPECTED_NOT_EXECUTED = {
+	"principles-persistence-clean-session-50":
+		"node connects with MQTT 3.1.1 (protocolVersion 4); the -311 variant is asserted instead",
+	"payloads-alias-uniqueness": "metric aliases are an optional feature group, not used by this node",
+	// Templates are an optional feature group. The node does support them, but
+	// the spec requires that if any assertion in an optional group is tested,
+	// all of them must pass - so the TCK fixture deliberately uses plain metrics.
+	"payloads-template-definition-members": "templates are an optional group, not used by the TCK fixture",
+	"payloads-template-definition-nbirth": "templates are an optional group, not used by the TCK fixture",
+	"payloads-template-definition-parameters": "templates are an optional group, not used by the TCK fixture",
+	"payloads-template-definition-parameters-default":
+		"templates are an optional group, not used by the TCK fixture",
+	"payloads-template-definition-ref": "templates are an optional group, not used by the TCK fixture",
+	"payloads-template-instance-members": "templates are an optional group, not used by the TCK fixture",
+	"payloads-template-instance-members-birth": "templates are an optional group, not used by the TCK fixture",
+	"payloads-template-instance-members-data": "templates are an optional group, not used by the TCK fixture",
+	"payloads-template-instance-parameters": "templates are an optional group, not used by the TCK fixture",
+	"payloads-template-instance-ref": "templates are an optional group, not used by the TCK fixture"
+};
+
+function parseOverall(resultText) {
+	const match = /OVERALL:\s*(.+?);/.exec(resultText);
+	return match ? match[1].trim() : "UNKNOWN";
+}
+
+/** Parse "assertion-id: RESULT;" lines out of a TCK summary. */
+function parseAssertions(resultText) {
+	const failed = [];
+	const notExecuted = [];
+	for (const line of resultText.split(/\r?\n/)) {
+		const match = /^([^:]+):\s*(.*);$/.exec(line.trim());
+		if (!match) continue;
+		const [, id, value] = match;
+		if (id === "OVERALL") continue;
+		if (value.startsWith("FAIL")) failed.push({ id, value });
+		// Monitor-level assertions going unexecuted is normal and the TCK itself
+		// ignores them when deciding INCOMPLETE.
+		else if (value === "NOT EXECUTED" && !id.startsWith("Monitor:") && !id.startsWith("MQTTListener"))
+			notExecuted.push(id);
+	}
+	return { failed, notExecuted };
+}
+
+async function runTest(control, observer, test) {
+	console.log(`\n=== ${test.name} ===`);
+	observer.reset();
+
+	// The Monitor keeps a per-edge-node bdSeq map for the whole broker session
+	// and only clears testResults between tests. Reloading the flow restarts the
+	// node under test with bdSeq 0, which would read as a regression. A distinct
+	// edge node id per test is the faithful analogue of the TCK's intended usage
+	// (each test run against a freshly started edge node).
+	const edgeNodeId = `${EDGE_NODE_ID}${test.name.replace("Test", "")}`;
+	const params = [HOST_APP_ID, GROUP_ID, edgeNodeId, DEVICE_ID];
+
+	const resultPromise = control.expectResult();
+
+	if (test.loadBeforeStart) {
+		await loadFlow(edgeNodeId, {});
+		// Let the node connect and subscribe to STATE before the TCK starts
+		// toggling the host.
+		await sleep(2000);
+		await control.startTest(test.name, params);
+	} else {
+		await control.startTest(test.name, params);
+		// Give the TCK a moment to register the test and bring its host online.
+		await sleep(1000);
+	}
+
+	let timedOut = false;
+	try {
+		await Promise.race([
+			(async () => {
+				await test.run({ observer, edgeNodeId });
+				await resultPromise;
+			})(),
+			(async () => {
+				await sleep(TEST_TIMEOUT_MS);
+				timedOut = true;
+				throw new Error(`test timed out after ${TEST_TIMEOUT_MS}ms`);
+			})()
+		]);
+	} catch (err) {
+		console.log(`  ! ${err.message}`);
+		// Ask the TCK to report whatever it has, so a hang still yields detail
+		// about which assertions were reached.
+		await control.endTest();
+	}
+
+	const resultText = await Promise.race([resultPromise, sleep(10000).then(() => null)]);
+	await unloadFlow();
+
+	if (!resultText) {
+		console.log("  RESULT: no result reported");
+		return { test: test.name, overall: "NO_RESULT", passed: false, timedOut, detail: null };
+	}
+
+	const overall = parseOverall(resultText);
+	const { failed, notExecuted } = parseAssertions(resultText);
+	const unexpectedNotExecuted = notExecuted.filter((id) => !(id in EXPECTED_NOT_EXECUTED));
+	const passed = overall.startsWith("PASS") && !failed.length && !unexpectedNotExecuted.length;
+
+	console.log(`  RESULT: ${overall}${passed ? "" : "  <- not accepted"}`);
+	for (const f of failed) console.log(`    FAILED    ${f.id}`);
+	for (const id of unexpectedNotExecuted) console.log(`    UNTESTED  ${id}`);
+
+	return {
+		test: test.name,
+		overall,
+		passed,
+		timedOut,
+		failed: failed.map((f) => f.id),
+		unexpectedNotExecuted,
+		detail: resultText
+	};
+}
+
+async function main() {
+	const requested = process.argv.slice(2);
+	const tests = requested.length ? TESTS.filter((t) => requested.includes(t.name)) : TESTS;
+
+	if (!tests.length) {
+		console.error(`No matching tests. Available: ${TESTS.map((t) => t.name).join(", ")}`);
+		process.exit(2);
+	}
+
+	console.log("Sparkplug TCK - Edge Node profile");
+	console.log(`  broker : ${BROKER_URL}`);
+	console.log(`  host   : ${HOST_APP_ID}`);
+	console.log(`  group  : ${GROUP_ID}`);
+
+	await new Promise((resolve) => helper.startServer(resolve));
+
+	const control = await TckControl.connect();
+	const observer = await Observer.connect();
+	const results = [];
+
+	try {
+		// Sequentially, never in parallel: the TCK holds one active test at a
+		// time and its simulated host is shared state.
+		for (const test of tests) {
+			results.push(await runTest(control, observer, test));
+		}
+	} finally {
+		control.end();
+		observer.end();
+		await new Promise((resolve) => helper.stopServer(resolve));
+	}
+
+	fs.writeFileSync(path.resolve(RESULTS_FILE), JSON.stringify(results, null, 2));
+
+	console.log("\n=== Summary ===");
+	for (const r of results) {
+		console.log(`  ${(r.passed ? "PASS" : "FAIL").padEnd(6)} ${r.test.padEnd(26)} ${r.overall}`);
+	}
+
+	const failed = results.filter((r) => !r.passed);
+	console.log(`\n${results.length - failed.length}/${results.length} passed`);
+	console.log(`Full detail written to ${RESULTS_FILE}`);
+	process.exit(failed.length ? 1 : 0);
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/test/tck/start-broker.sh
+++ b/test/tck/start-broker.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Start a HiveMQ broker with the Eclipse Sparkplug TCK extension loaded.
+#
+# Used both locally and by .github/workflows/tck.yml. The TCK's own Gradle task
+# (runHivemqWithExtension) pins HiveMQ CE 2021.1, whose bundled JNA has no arm64
+# native library - it dies on Apple Silicon. We download a current HiveMQ CE
+# instead, which runs on both arm64 and x86_64.
+#
+# Usage:
+#   test/tck/start-broker.sh <path-to-sparkplug-checkout>
+#
+# Runs in the foreground; Ctrl-C to stop.
+
+set -euo pipefail
+
+SPARKPLUG_DIR="${1:-ref/sparkplug}"
+HIVEMQ_VERSION="${HIVEMQ_VERSION:-2024.9}"
+WORK_DIR="${TCK_WORK_DIR:-.tck-broker}"
+CACHE_DIR="${TCK_CACHE_DIR:-$WORK_DIR/cache}"
+# Overridable so the TCK broker can coexist with a mosquitto already on 1883
+# (the mocha suite's broker). Keep TCK_BROKER in run-tck.js in sync.
+HIVEMQ_PORT="${HIVEMQ_PORT:-1883}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_ZIP="$SPARKPLUG_DIR/tck/build/hivemq-extension/sparkplug-tck-3.0.0.zip"
+
+if [ ! -f "$EXTENSION_ZIP" ]; then
+    echo "TCK extension not built. Run:"
+    echo "  (cd $SPARKPLUG_DIR && ./gradlew -p tck hivemqExtensionZip)"
+    echo ""
+    echo "Note: the tck/ directory ships a gradlew without its wrapper jar, so the"
+    echo "root wrapper with -p tck is the way to build it."
+    exit 1
+fi
+
+mkdir -p "$CACHE_DIR"
+HIVEMQ_ZIP="$CACHE_DIR/hivemq-ce-$HIVEMQ_VERSION.zip"
+
+if [ ! -f "$HIVEMQ_ZIP" ]; then
+    echo "Downloading HiveMQ CE $HIVEMQ_VERSION..."
+    curl -fsSL -o "$HIVEMQ_ZIP" \
+        "https://github.com/hivemq/hivemq-community-edition/releases/download/$HIVEMQ_VERSION/hivemq-ce-$HIVEMQ_VERSION.zip"
+fi
+
+HIVEMQ_HOME="$WORK_DIR/hivemq-ce-$HIVEMQ_VERSION"
+if [ ! -d "$HIVEMQ_HOME" ]; then
+    echo "Unpacking HiveMQ CE $HIVEMQ_VERSION..."
+    unzip -q "$HIVEMQ_ZIP" -d "$WORK_DIR"
+fi
+
+# Install / refresh the TCK extension.
+rm -rf "$HIVEMQ_HOME/extensions/sparkplug-tck"
+unzip -q -o "$EXTENSION_ZIP" -d "$HIVEMQ_HOME/extensions"
+
+sed "s|<port>1883</port>|<port>$HIVEMQ_PORT</port>|" \
+    "$SCRIPT_DIR/hivemq-config.xml" > "$HIVEMQ_HOME/conf/config.xml"
+
+# The TCK appends to its results log, so a previous failing run would otherwise
+# be reported again. The UserGuide calls this out explicitly.
+rm -f "$HIVEMQ_HOME/bin/SparkplugTCKResults.log"
+
+echo "Starting HiveMQ CE $HIVEMQ_VERSION with the Sparkplug TCK extension on port $HIVEMQ_PORT..."
+exec "$HIVEMQ_HOME/bin/run.sh"

--- a/test/tck/tck-flow.js
+++ b/test/tck/tck-flow.js
@@ -1,0 +1,76 @@
+/**
+ * Node-RED flow fixture used by the Sparkplug TCK harness (run-tck.js).
+ *
+ * Shaped after `simpleFlow` in test/sparkplug_device__spec.js, but parameterized
+ * so each TCK test can pick its own group / edge node / device IDs and decide
+ * whether the Primary Host (STATE) gate is active.
+ */
+
+/**
+ * Build a flow containing an EoN broker node, one device and one generic
+ * sparkplug-out node (used to emit NDATA in the SendData test).
+ *
+ * @param {object} opts
+ * @param {string} opts.groupId          Sparkplug Group ID
+ * @param {string} opts.edgeNodeId       Sparkplug Edge Node ID
+ * @param {string} opts.deviceId         Sparkplug Device ID
+ * @param {string} opts.brokerHost       broker hostname
+ * @param {string|number} opts.brokerPort broker port
+ * @param {object} [opts.metrics]        device metric definitions
+ * @param {string} [opts.primaryScada]   Primary Host Application ID. When set,
+ *                                       store-forward is enabled so the node
+ *                                       gates NBIRTH on STATE (see README).
+ * @param {string} [opts.username]
+ * @param {string} [opts.password]
+ * @returns {Array} Node-RED flow
+ */
+function buildFlow(opts) {
+	const usePrimaryHost = typeof opts.primaryScada === "string" && opts.primaryScada !== "";
+
+	return [
+		{
+			id: "device",
+			type: "mqtt sparkplug device",
+			name: opts.deviceId,
+			// The TCK's edge tests only require that whatever we birth, we then
+			// report consistently, so a pair of simple metrics is enough.
+			// Note this node only publishes DBIRTH once *every* configured
+			// metric has a value, so the harness must feed all of them.
+			metrics: opts.metrics || {
+				"test/int": { dataType: "Int32" },
+				"test/bool": { dataType: "Boolean" }
+			},
+			broker: "broker",
+			wires: [[]]
+		},
+		{
+			id: "out",
+			type: "mqtt sparkplug out",
+			name: "raw out",
+			topic: "",
+			qos: "0",
+			retain: false,
+			broker: "broker"
+		},
+		{
+			id: "broker",
+			type: "mqtt-sparkplug-broker",
+			name: "TCK broker",
+			deviceGroup: opts.groupId,
+			eonName: opts.edgeNodeId,
+			broker: opts.brokerHost,
+			port: String(opts.brokerPort),
+			clientid: "",
+			usetls: false,
+			protocolVersion: "4",
+			keepalive: "60",
+			cleansession: true,
+			enableStoreForward: usePrimaryHost,
+			primaryScada: usePrimaryHost ? opts.primaryScada : "",
+			username: opts.username || "",
+			password: opts.password || ""
+		}
+	];
+}
+
+module.exports = { buildFlow };


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs the Eclipse Sparkplug TCK (Edge Node profile) against these nodes on every PR and push to main.

The TCK is documented as a manual process driven from a Nuxt web console, but the console is only an MQTT client: the control plane is plain MQTT topics (SPARKPLUG_TCK/TEST_CONTROL, /RESULT, /LOG). test/tck/run-tck.js speaks that protocol directly and drives the nodes in-process with node-red-node-test-helper. No Edge Node test calls the TCK's prompt(), and the TCK brings its own simulated Host Application online, so nothing needs a human.

Notes for anyone touching this, expanded on in test/tck/README.md:

* The broker must be on port 1883. The TCK's utility clients hardcode tcp://localhost:1883 (TCK.java:53, HostApplication.java:50) with no override. Point it elsewhere and tests hang waiting for a birth that never comes.
* start-broker.sh uses a current HiveMQ CE rather than the 2021.1 pinned by the TCK's own Gradle task, whose bundled JNA is x86-only and dies on arm64.
* The broker needs restarting between full runs: the TCK's Monitor keeps a per-edge-node bdSeq map for the broker's lifetime and never clears it. Each test already gets its own edge node ID to limit the damage.

A run is accepted only when OVERALL is PASS, no assertion failed, and every NOT EXECUTED assertion is in a documented allowlist, so new coverage gaps do not hide behind the TCK's "but INCOMPLETE" suffix.