### PR TITLE
Additional TCK fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,59 @@
+### Unreleased : session lifecycle conformance
+
+These issues were catalogued by the `node-red-contrib-mqtt-sparkplug-plus-wmonitor`
+fork (ISC, Michael Sadowski), which branched from v2.2.4 and fixed them there. They
+were re-verified and fixed independently against this code base; each one has a test
+in `test/sparkplug_lifecycle_spec.js` that fails without its fix.
+
+**Behaviour change:** the configured MQTT protocol version is now actually applied.
+It was read from the broker configuration but never passed to the MQTT client, so
+every connection was MQTT 3.1.1 regardless of the setting. **A configuration already
+set to MQTT 5.0 will now genuinely connect as 5.0** - if the broker treats the two
+differently, that changes on upgrade. With 5.0 the Edge Node also sets Clean Start
+and a Session Expiry Interval of 0, so no session outlives its connection
+(tck-id-principles-persistence-clean-session-50).
+
+**Behaviour change:** metric aliases are now allocated per device rather than per
+metric name. Two devices under one Edge Node that share a metric name previously
+received the *same* alias, which breaks the requirement that an alias be unique
+across the Edge Node's entire set of metrics (tck-id-payloads-alias-uniqueness).
+Alias numbers therefore differ from previous releases; they are republished in every
+birth message, so subscribers pick the new mapping up automatically.
+
+Fixed:
+- bdSeq now wraps from 255 to 0. It previously reached 256 before wrapping, one step
+  outside the permitted range.
+- bdSeq is taken, and the matching NDEATH re-registered as the will, for *every*
+  CONNECT - including the automatic reconnects MQTT.js performs on its own.
+  Previously only a deliberate connect advanced it, so every session after the first
+  reused the first session's bdSeq, which
+  tck-id-topics-nbirth-bdseq-increment forbids.
+- bdSeq is kept in global context instead of the config node's own context, which
+  Node-RED clears on redeploy. Surviving a full process restart additionally needs
+  `contextStorage` configured in `settings.js`; without it behaviour is unchanged.
+- The will is registered with an explicit retained flag of false
+  (tck-id-message-flow-edge-node-birth-publish-will-message-will-retained).
+- A negative Int64 metric no longer decodes as a huge positive number. Sparkplug
+  carries Int64 in an unsigned protobuf field and `sparkplug-payload` only converts
+  it back when its own `instanceof Long` check matches - which it does not, because
+  protobufjs builds the value from a different copy of `long`. -42 arrived as
+  18446744073709551574.
+- MQTT connection errors are reported instead of being silently discarded, so a
+  rejected certificate or bad credentials is visible rather than presenting as a
+  connection that never comes up. Repeats of the same error are logged once, and
+  reported again after a successful connection in between.
+- Every metric in an NBIRTH now carries a timestamp. Template definitions come
+  straight from the configuration and had none
+  (tck-id-payloads-name-birth-data-requirement).
+- With MQTT 5.0 the DISCONNECT sent on an intentional shutdown carries the
+  'Disconnect with Will Message' reason code (0x04), so the broker publishes the will
+  as well rather than discarding it
+  (tck-id-payloads-ndeath-will-message-publisher-disconnect-mqtt50).
+- MQTT.js no longer queues QoS 0 publishes while offline and flushes them after a
+  reconnect. They arrived after the new NBIRTH had reset the sequence number, so the
+  host saw the sequence jump backwards and asked for a rebirth. Replaying buffered
+  data is Store Forward's job, and it replays with current sequence numbers.
+
 ### 3.0.0 : Sparkplug TCK conformance
 
 **Behaviour change:** the Primary Host ID ("Destination") is now independent of

--- a/locales/en-US/mqtt-sparkplug-plus.json
+++ b/locales/en-US/mqtt-sparkplug-plus.json
@@ -102,7 +102,8 @@
             "not-defined": "Topic is not defined",
             "invalid-metric-definition": "Unable to use '__name__' as a metric. the error is : __error__",
             "unable-to-deserialize-templates" : "Unable to parse templates. The error is : __error__",
-            "invalid-metric-data": "Unable to send data for metric '__name__'. the error is : __error__"
+            "invalid-metric-data": "Unable to send data for metric '__name__'. the error is : __error__",
+            "connection-error": "MQTT connection error (__broker__): __error__"
         }
     }	
 }

--- a/mqtt-sparkplug-plus.js
+++ b/mqtt-sparkplug-plus.js
@@ -152,6 +152,15 @@ module.exports = function(RED) {
                 if (long.isLong(m.timestamp)) {
                     m.timestamp = new Date(m.timestamp.toNumber());
                 }
+                // Sparkplug carries Int64 in an unsigned protobuf field. sparkplug-payload
+                // converts it back to signed only when its own `instanceof Long` check
+                // matches, and it does not: protobufjs builds the value from a different
+                // copy of `long` than the one the library tests against. A negative Int64
+                // then surfaces as a huge positive number (-42 as 18446744073709551574).
+                // UInt64 is genuinely unsigned and is left alone.
+                if (m.type === "Int64" && long.isLong(m.value) && m.value.unsigned) {
+                    m.value = m.value.toSigned();
+                }
             })
         }
         return payload;
@@ -308,7 +317,16 @@ module.exports = function(RED) {
                      };
  
                      if (node.brokerConn.aliasMetrics && msg.payload.hasOwnProperty("metrics")) {
-                         let lookup = Object.entries(node.brokerConn.metricsAliasMap).reduce((acc, [key, value]) => (acc[value] = key, acc), {})
+                         // The alias map is keyed by device, so only this device's entries
+                         // may resolve here - and the device prefix comes back off before
+                         // the name is handed on.
+                         let prefix = node.brokerConn.getAliasKey(node.name, "");
+                         let lookup = Object.entries(node.brokerConn.metricsAliasMap).reduce(function(acc, [key, value]) {
+                             if (key.startsWith(prefix)) {
+                                 acc[value] = key.substring(prefix.length);
+                             }
+                             return acc;
+                         }, {});
                          msg.payload.metrics.forEach(m=> {
                              if (long.isLong(m.alias)) {
                                  m.alias = m.alias;
@@ -788,6 +806,9 @@ module.exports = function(RED) {
         this.connected = false;
         this.connecting = false;
         this.closing = false;
+        // Last reported connection error, so a permanent failure is logged once
+        // rather than on every reconnect attempt.
+        this.lastConnectionError = null;
         this.options = {};
         this.subscriptions = {};
         this.bdSeq = -1;
@@ -898,24 +919,31 @@ module.exports = function(RED) {
         };
 
         /**
-         * We Store bdSeq in context, as a redeployment of the node can cause 
-         * 
-         * FIXME: context for config nodes are reset on redeploy (node-red bug) We still have the logic to store bdSeq in Context, if it get fixed on day
-         * redeploy should always be gracefull shutdown, so it should not cause any issues (I think) 
+         * bdSeq is kept in *global* context rather than this node's own: Node-RED
+         * clears a config node's context on redeploy, so a counter kept there
+         * restarts at 0 and the host sees two sessions claiming the same bdSeq.
+         * The key is per node, so several broker nodes never share one counter.
+         *
+         * Surviving a process restart additionally needs contextStorage configured
+         * in settings.js. Without it this is memory-only, which is no worse than
+         * before.
+         *
          * @returns the next birth sequence number
          */
+        this.bdSeqContextKey = "sparkplugBdSeq_" + this.id;
         this.nextBdseq = function() {
-            let bdSeq = this.context().get("bdSeq");
-            if (bdSeq === undefined) { // we can't || here because it will also filter out 0
-                bdSeq = -1;
-            }
-            if (bdSeq > 255) {
-                bdSeq = 0;
-            } else {
-                bdSeq += 1;
-            }
-            this.context().set("bdSeq", bdSeq);
-            this.bdSeq = bdSeq;
+            // Not `||`: that would swallow a stored 0 as well as "never set".
+            let stored = node.context().global.get(node.bdSeqContextKey);
+            let bdSeq = stored === undefined ? -1 : stored;
+
+            // [tck-id-message-flow-edge-node-birth-publish-will-message-payload-bdSeq]
+            // bdSeq is 0-255 inclusive, so 255 is followed by 0. Comparing against
+            // 255 rather than 256 is what keeps it in range - the previous `> 255`
+            // let the counter reach 256 before wrapping.
+            bdSeq = bdSeq >= 255 ? 0 : bdSeq + 1;
+
+            node.context().global.set(node.bdSeqContextKey, bdSeq);
+            node.bdSeq = bdSeq;
             return bdSeq;
         };
 
@@ -951,7 +979,7 @@ module.exports = function(RED) {
             }
 
             if (node.aliasMetrics) {
-                msg.payload.metrics = node.addAliasMetrics(msgType, msg.payload.metrics);
+                msg.payload.metrics = node.addAliasMetrics(msgType, msg.payload.metrics, deviceName);
             }
             try {
                 if (node.compressAlgorithm) {
@@ -973,11 +1001,21 @@ module.exports = function(RED) {
         };
         this.nextMetricAlias = 0;
         this.metricsAliasMap = {};
+
         /**
-         * Convert metric names to metric aliases. 
+         * Key a metric in the alias map. Keyed by device, because the same metric
+         * name on two devices is two distinct metrics of this Edge Node. The Edge
+         * Node's own metrics use an empty device name.
+         */
+        this.getAliasKey = function(deviceName, metricName) {
+            return (deviceName || "") + "/" + metricName;
+        };
+
+        /**
+         * Convert metric names to metric aliases.
          * This method expect that the metrics attribute name exists
          */
-        this.addAliasMetrics = function(msgType, metrics) {
+        this.addAliasMetrics = function(msgType, metrics, deviceName) {
             return metrics.map(metric => {
 
                 // [tck-id-operational-behavior-data-commands-rebirth-name-aliases] When aliases are being used by an Edge Node an NBIRTH message MUST NOT include an alias for the Node Control/Rebirth metric.
@@ -985,12 +1023,17 @@ module.exports = function(RED) {
                     return metric;
                 }
 
+                // [tck-id-payloads-alias-uniqueness] The alias MUST be unique across this
+                // Edge Node's entire set of metrics. Keying on the metric name alone gave
+                // two devices sharing a name the same alias.
+                let aliasKey = node.getAliasKey(deviceName, metric.name);
+
                 // Update the alias map if necessary
-                if (!node.metricsAliasMap.hasOwnProperty(metric.name)) {
-                    node.metricsAliasMap[metric.name] = ++node.nextMetricAlias;
+                if (!node.metricsAliasMap.hasOwnProperty(aliasKey)) {
+                    node.metricsAliasMap[aliasKey] = ++node.nextMetricAlias;
                 }
 
-                metric.alias = node.metricsAliasMap[metric.name];
+                metric.alias = node.metricsAliasMap[aliasKey];
                 // Remove the name property if the message type is not NBIRTH or DBIRTH
                 if (msgType != "NBIRTH" && msgType != "DBIRTH") {
                     delete metric.name;
@@ -1070,6 +1113,14 @@ module.exports = function(RED) {
                 }
             }            
             let ts = Date.now();
+            // [tck-id-payloads-name-birth-data-requirement] Every metric in a birth
+            // message carries a timestamp. Template definitions come straight from the
+            // configuration and have none of their own.
+            birthMessageMetrics.forEach(m => {
+                if (!m.timestamp) {
+                    m.timestamp = ts;
+                }
+            });
             birthMessageMetrics = birthMessageMetrics.concat([
                 {
                     "name" : "Node Control/Rebirth",
@@ -1187,7 +1238,27 @@ module.exports = function(RED) {
         this.options.password = this.password;
         this.options.keepalive = this.keepalive;
         this.options.clean = this.cleansession;
+        // Previously read from the config but never passed on, so every connection
+        // was MQTT 3.1.1 whatever the node said.
+        this.options.protocolVersion = parseInt(this.protocolVersion, 10) || 4;
+
+        if (this.options.protocolVersion === 5) {
+            // [tck-id-principles-persistence-clean-session-50] An MQTT 5.0 Edge Node
+            // MUST connect with Clean Start true and Session Expiry Interval 0. A
+            // session that outlived the connection would let the broker replay data
+            // from a dead session after the next NBIRTH.
+            this.options.clean = true;
+            this.options.properties = Object.assign({}, this.options.properties, {
+                sessionExpiryInterval: 0
+            });
+        }
+
         this.options.reconnectPeriod = RED.settings.mqttReconnectTime||5000;
+        // MQTT.js queues QoS 0 publishes while offline and flushes them after the
+        // reconnect - that is, after the new NBIRTH has reset seq to 0 - so the host
+        // sees the sequence jump backwards and asks for a rebirth. Replaying buffered
+        // data is store-and-forward's job, and it replays with current sequence numbers.
+        this.options.queueQoSZero = false;
      
         if (this.usetls && n.tls) {
             var tlsNode = RED.nodes.getNode(n.tls);
@@ -1285,10 +1356,16 @@ module.exports = function(RED) {
             }
 
             node.publish(node.getDeathPayload(), false, function(err) {
+                // [tck-id-payloads-ndeath-will-message-publisher-disconnect-mqtt50] With
+                // MQTT 5.0 a plain DISCONNECT tells the broker to discard the will;
+                // reason code 0x04 ("Disconnect with Will Message") asks it to publish
+                // the will too. MQTT 3.1.1 has no reason codes.
+                let disconnectOptions = node.options.protocolVersion === 5 ? { reasonCode: 4 } : {};
+
                 // [tck-id-operational-behavior-edge-node-intentional-disconnect-packet]
                 // force MUST be false so mqtt.js emits a DISCONNECT packet; end(true)
                 // destroys the socket without sending one.
-                node.client.end(false, {}, function() {
+                node.client.end(false, disconnectOptions, function() {
                     // end(false) defers 'close' past the NDEATH round-trip, so clear
                     // the connection flags here rather than waiting for that event.
                     node.connected = false;
@@ -1326,6 +1403,36 @@ module.exports = function(RED) {
         };
 
         /**
+         * Take the next bdSeq and register the matching NDEATH as the will for the
+         * next CONNECT packet.
+         *
+         * Called for every CONNECT, not just the deliberate ones: MQTT.js reconnects
+         * on its own, and builds that CONNECT from the options it is holding. Without
+         * this, every session after the first would re-use the will - and therefore
+         * the bdSeq - of the original connection.
+         */
+        this.registerNextWill = function() {
+            node.nextBdseq();
+
+            let will = node.getDeathPayload();
+            if (will) {
+                // [tck-id-message-flow-edge-node-birth-publish-will-message-qos] QoS MUST
+                // be 1, or the broker is free to drop the NDEATH.
+                // [tck-id-message-flow-edge-node-birth-publish-will-message-will-retained]
+                // The retained flag MUST be false.
+                will.qos = 1;
+                will.retain = false;
+            }
+            node.options.will = will;
+
+            // mqtt.connect() copies the options, so a live client holds its own copy -
+            // and that copy is what its next CONNECT packet is built from.
+            if (node.client) {
+                node.client.options.will = will;
+            }
+        };
+
+        /**
          * Connect to the MQTT Broker
          */
         this.connect = function () {
@@ -1335,11 +1442,9 @@ module.exports = function(RED) {
             if (!node.connected && !node.connecting) {
                 node.connecting = true;
                 try {
-                    this.nextBdseq(); // Next connect will use next bdSeq
+                    this.registerNextWill();
                     node.nbirthSent = false; // new session -> NBIRTH is due again
                     node.deathSent = false;  // ...and its deaths are due again on close
-                    node.options.will = this.getDeathPayload();
-                    if (node.options.will) node.options.will.qos = 1;
                     node.serverProperties = {};
                     node.client = mqtt.connect(node.brokerurl ,node.options);
                     node.client.setMaxListeners(0);
@@ -1347,6 +1452,9 @@ module.exports = function(RED) {
                     node.client.on('connect', function (connack) {
                         node.connecting = false;
                         node.connected = true;
+                        // A failure after a good connection is news again, even if it
+                        // happens to be the same error as last time.
+                        node.lastConnectionError = null;
                         node.log(RED._("mqtt-sparkplug-plus.state.connected",{broker:(node.clientid?node.clientid+"@":"")+node.brokerurl}));
                         for (var id in node.users) {
                             if (node.users.hasOwnProperty(id)) {
@@ -1473,6 +1581,12 @@ module.exports = function(RED) {
                     });
 
                     node.client.on("reconnect", function() {
+                        // [tck-id-topics-nbirth-bdseq-increment] Fires immediately before
+                        // MQTT.js writes the new CONNECT, which is built from the options
+                        // as they stand at that moment - so this is where the next
+                        // session's bdSeq and will are put in place. The NBIRTH that
+                        // follows the CONNACK then carries the same bdSeq.
+                        node.registerNextWill();
                         for (var id in node.users) {
                             if (node.users.hasOwnProperty(id)) {
                                 node.setConnectionState(node.users[id], "RECONNECTING");
@@ -1505,9 +1619,20 @@ module.exports = function(RED) {
                         }
                     });
 
-                    // Register connect error handler
-                    // The client's own reconnect logic will take care of errors
+                    // The client's own reconnect logic recovers from these, but swallowing
+                    // them entirely hides *why* a connection never comes up - bad
+                    // credentials, a rejected certificate, an unknown host. Identical
+                    // consecutive errors are reported once so a permanent failure does not
+                    // restate itself on every reconnect interval.
                     node.client.on('error', function (error) {
+                        let message = error && error.message ? error.message : String(error);
+                        if (message !== node.lastConnectionError) {
+                            node.lastConnectionError = message;
+                            node.error(RED._("mqtt-sparkplug-plus.errors.connection-error", {
+                                broker: node.brokerurl,
+                                error: message
+                            }));
+                        }
                     });
                 }catch(err) {
                     console.log(err);

--- a/test/sparkplug_lifecycle_spec.js
+++ b/test/sparkplug_lifecycle_spec.js
@@ -1,0 +1,508 @@
+/**
+ * Session lifecycle conformance: bdSeq allocation, will registration, protocol
+ * version handling, alias uniqueness, birth timestamps, payload decoding and
+ * connection error reporting.
+ *
+ * The issues covered here were catalogued by the `-wmonitor` fork
+ * (ISC, Michael Sadowski), which branched from v2.2.4 and fixed them there.
+ * These tests were written independently against this code base; each one fails
+ * without its corresponding fix.
+ */
+var helper = require("node-red-node-test-helper");
+var sparkplugNode = require("../mqtt-sparkplug-plus.js");
+var should = require("should");
+var mqtt = require("mqtt");
+
+var spPayload = require('sparkplug-payload').get("spBv1.0");
+helper.init(require.resolve('node-red'));
+
+let testBroker = process.env.TEST_BROKER || 'mqtt://localhost';
+const _brokerUrl = new URL(testBroker.replace(/^mqtt(s?)/, 'http$1'));
+let brokerHost = _brokerUrl.hostname;
+let brokerPort = _brokerUrl.port || '1883';
+let brokerUsername = _brokerUrl.username || '';
+let brokerPassword = _brokerUrl.password || '';
+
+var client = null;
+
+/** Broker config node. `overrides` is merged last so a test can vary one field. */
+function brokerNode(overrides) {
+	return Object.assign({
+		"id": "b1",
+		"type": "mqtt-sparkplug-broker",
+		"name": "Lifecycle Broker",
+		"deviceGroup": "Lifecycle Devices",
+		"eonName": "Lifecycle-EoN",
+		"broker": brokerHost,
+		"port": brokerPort,
+		"clientid": "",
+		"usetls": false,
+		"protocolVersion": "4",
+		"keepalive": "60",
+		"cleansession": true,
+		"enableStoreForward": false,
+		"primaryScada": "",
+		"username": brokerUsername,
+		"password": brokerPassword
+	}, overrides || {});
+}
+
+/** Device node bound to `b1`. */
+function deviceNode(id, name, metrics) {
+	return {
+		"id": id,
+		"type": "mqtt sparkplug device",
+		"name": name,
+		"metrics": metrics,
+		"broker": "b1"
+	};
+}
+
+function metricsOf(message) {
+	return spPayload.decodePayload(Buffer.from(message)).metrics;
+}
+
+/**
+ * Run assertions inside a callback and hand any failure to mocha.
+ *
+ * Without this an assertion that throws inside a node/MQTT callback never reaches
+ * the runner: done() is simply never called and the test dies as an unexplained
+ * "Timeout of 2000ms exceeded", which says nothing about what actually broke.
+ */
+function check(done, assertions) {
+	try {
+		assertions();
+		done();
+	} catch (err) {
+		done(err);
+	}
+}
+
+/** Call `assertions` once the broker config node has a live client. */
+function whenClientReady(broker, done, assertions) {
+	let waiting = setInterval(function () {
+		if (!broker.client) { return; }
+		clearInterval(waiting);
+		assertions();
+	}, 25);
+	// Surface a stalled connection as a clear failure rather than a bare timeout.
+	setTimeout(function () {
+		if (waiting) { clearInterval(waiting); }
+	}, 1800);
+}
+
+describe('sparkplug lifecycle', function () {
+
+	beforeEach(function (done) {
+		helper.startServer(done);
+	});
+
+	afterEach(async function () {
+		await helper.unload();
+		helper.stopServer();
+		if (client) {
+			client.end(true);
+			client = null;
+		}
+	});
+
+	// ── bdSeq allocation ────────────────────────────────────────────────────
+
+	describe('bdSeq', function () {
+
+		/**
+		 * [tck-id-message-flow-edge-node-birth-publish-will-message-payload-bdSeq]
+		 * bdSeq is a value 0-255; after 255 the next value MUST be 0.
+		 */
+		it('should wrap from 255 to 0 without ever emitting 256', function (done) {
+			helper.load(sparkplugNode, [brokerNode()], {}, function () {
+				check(done, function () {
+					let broker = helper.getNode("b1");
+					let seen = [];
+					for (let i = 0; i < 258; i++) {
+						seen.push(broker.nextBdseq());
+					}
+					seen.should.not.containEql(256);
+					Math.max.apply(null, seen).should.eql(255);
+					// The value after 255 must be 0, not anything else.
+					seen[seen.indexOf(255) + 1].should.eql(0);
+				});
+			});
+		});
+
+		/**
+		 * A redeploy re-creates the config node and wipes its node context, so a
+		 * bdSeq kept there restarts at 0 and the host sees two sessions claiming the
+		 * same number. Global context outlives the node, which is what makes the
+		 * counter survive - asserted on placement rather than by redeploying,
+		 * because the test helper tears the runtime down between loads.
+		 */
+		it('should keep bdSeq in global context, not the node context', function (done) {
+			helper.load(sparkplugNode, [brokerNode()], {}, function () {
+				check(done, function () {
+					let broker = helper.getNode("b1");
+					let value = broker.nextBdseq();
+
+					should.exist(broker.bdSeqContextKey, "no global context key defined for bdSeq");
+					should.exist(broker.context().global.get(broker.bdSeqContextKey),
+						"bdSeq was not written to global context, so a redeploy resets it");
+					broker.context().global.get(broker.bdSeqContextKey).should.eql(value);
+					should.not.exist(broker.context().get("bdSeq"),
+						"bdSeq is still kept in node context, which a redeploy clears");
+
+					// Per node, so two broker nodes cannot share one counter.
+					broker.bdSeqContextKey.should.containEql(broker.id);
+				});
+			});
+		});
+
+		/**
+		 * [tck-id-topics-nbirth-bdseq-increment] The bdSeq MUST increment on every
+		 * new MQTT CONNECT. MQTT.js reconnects on its own, and the will it sends
+		 * with that CONNECT is built from the options it already holds - so both
+		 * the counter and the client's own will have to be refreshed.
+		 */
+		it('should take a new bdSeq and will for an automatic reconnect', function (done) {
+			let flow = [deviceNode("d1", "Device1", { "t": { "dataType": "Int32" } }), brokerNode()];
+			helper.load(sparkplugNode, flow, {}, function () {
+				let broker = helper.getNode("b1");
+				whenClientReady(broker, done, function () {
+					check(done, function () {
+						let bdSeqBefore = broker.bdSeq;
+						let willBefore = bdSeqOfWill(broker.client.options.will);
+
+						// What MQTT.js emits immediately before writing a new CONNECT.
+						broker.client.emit('reconnect');
+
+						broker.bdSeq.should.eql(bdSeqBefore + 1,
+							"bdSeq did not advance for the reconnect");
+						bdSeqOfWill(broker.client.options.will).should.eql(willBefore + 1,
+							"the client's will still carries the previous bdSeq");
+					});
+				});
+			});
+		});
+
+		function bdSeqOfWill(will) {
+			should.exist(will, "no will registered on the client");
+			let metric = metricsOf(will.payload).find(m => m.name === "bdSeq");
+			should.exist(metric, "will payload has no bdSeq metric");
+			return typeof metric.value === "object" ? metric.value.toNumber() : metric.value;
+		}
+	});
+
+	// ── Connection options ──────────────────────────────────────────────────
+
+	describe('connection options', function () {
+
+		it('should apply the configured MQTT protocol version', function (done) {
+			helper.load(sparkplugNode, [brokerNode({ "protocolVersion": "5" })], {}, function () {
+				check(done, function () {
+					should.exist(helper.getNode("b1").options.protocolVersion,
+						"protocolVersion was read from the config but never passed to MQTT.js");
+					helper.getNode("b1").options.protocolVersion.should.eql(5);
+				});
+			});
+		});
+
+		/**
+		 * [tck-id-principles-persistence-clean-session-50] With MQTT 5.0 the
+		 * CONNECT MUST set Clean Start true and Session Expiry Interval 0, so no
+		 * session outlives the connection.
+		 */
+		it('should set clean start and a zero session expiry on MQTT 5.0', function (done) {
+			helper.load(sparkplugNode, [brokerNode({ "protocolVersion": "5", "cleansession": false, "clientid": "fixed-id" })], {}, function () {
+				check(done, function () {
+					let options = helper.getNode("b1").options;
+					options.clean.should.eql(true, "Clean Start was not forced on for MQTT 5.0");
+					should.exist(options.properties, "no MQTT 5.0 properties set");
+					options.properties.sessionExpiryInterval.should.eql(0);
+				});
+			});
+		});
+
+		it('should default to MQTT 3.1.1 when nothing is configured', function (done) {
+			helper.load(sparkplugNode, [brokerNode({ "protocolVersion": undefined })], {}, function () {
+				check(done, function () {
+					should.exist(helper.getNode("b1").options.protocolVersion,
+						"no protocolVersion passed to MQTT.js at all");
+					helper.getNode("b1").options.protocolVersion.should.eql(4);
+				});
+			});
+		});
+
+		/**
+		 * MQTT.js queues QoS 0 publishes while offline and flushes them after the
+		 * reconnect - i.e. after the new NBIRTH has reset seq to 0 - so the host
+		 * sees the sequence jump backwards. Store-and-forward is what replays
+		 * data, with current sequence numbers.
+		 */
+		it('should not let MQTT.js queue QoS 0 publishes across a reconnect', function (done) {
+			helper.load(sparkplugNode, [brokerNode()], {}, function () {
+				check(done, function () {
+					let options = helper.getNode("b1").options;
+					should.exist(options.queueQoSZero,
+						"queueQoSZero was never set, so MQTT.js keeps its queue-and-replay default");
+					options.queueQoSZero.should.eql(false);
+				});
+			});
+		});
+	});
+
+	// ── Disconnect ──────────────────────────────────────────────────────────
+
+	describe('intentional disconnect', function () {
+
+		/**
+		 * [tck-id-payloads-ndeath-will-message-publisher-disconnect-mqtt50] A plain
+		 * MQTT 5.0 DISCONNECT tells the broker to discard the will; reason code
+		 * 0x04 asks it to publish the will as well.
+		 */
+		it('should send the Disconnect with Will Message reason code on MQTT 5.0', function (done) {
+			let flow = [deviceNode("d1", "Device1", { "t": { "dataType": "Int32" } }), brokerNode({ "protocolVersion": "5" })];
+			helper.load(sparkplugNode, flow, {}, function () {
+				let broker = helper.getNode("b1");
+
+				whenClientReady(broker, done, function () {
+					let endOptions = null;
+					broker.client.end = function (force, options, cb) {
+						endOptions = options;
+						if (typeof cb === 'function') { cb(); }
+					};
+
+					broker.sendDeathsAndDisconnect(function () {
+						check(done, function () {
+							should.exist(endOptions, "client.end() was called without options");
+							endOptions.should.have.property("reasonCode", 4);
+						});
+					});
+				});
+			});
+		});
+
+		it('should not send a reason code on MQTT 3.1.1', function (done) {
+			let flow = [deviceNode("d1", "Device1", { "t": { "dataType": "Int32" } }), brokerNode()];
+			helper.load(sparkplugNode, flow, {}, function () {
+				let broker = helper.getNode("b1");
+
+				whenClientReady(broker, done, function () {
+					let endOptions = null;
+					broker.client.end = function (force, options, cb) {
+						endOptions = options;
+						if (typeof cb === 'function') { cb(); }
+					};
+
+					broker.sendDeathsAndDisconnect(function () {
+						check(done, function () {
+							(endOptions || {}).should.not.have.property("reasonCode");
+						});
+					});
+				});
+			});
+		});
+	});
+
+	// ── Connection errors ───────────────────────────────────────────────────
+
+	describe('connection errors', function () {
+
+		it('should report connection errors instead of swallowing them', function (done) {
+			helper.load(sparkplugNode, [deviceNode("d1", "Device1", { "t": { "dataType": "Int32" } }), brokerNode()], {}, function () {
+				let broker = helper.getNode("b1");
+
+				// The helper only instruments regular nodes, not config nodes, so
+				// 'call:error' never fires here - capture the call directly instead.
+				// RED._ returns the key rather than the text under test, so the key is
+				// what there is to assert on, as the other specs do.
+				let reported = [];
+				broker.error = function (message) { reported.push(message); };
+
+				whenClientReady(broker, done, function () {
+					check(done, function () {
+						broker.client.emit('error', new Error("Connection refused: Not authorized"));
+						reported.length.should.eql(1, "the connection error was swallowed");
+						reported[0].should.eql('mqtt-sparkplug-plus.errors.connection-error');
+
+						// A permanent failure retries on a timer; it must not flood the log.
+						broker.client.emit('error', new Error("Connection refused: Not authorized"));
+						reported.length.should.eql(1, "the same error was reported on every retry");
+
+						// A different failure is news again.
+						broker.client.emit('error', new Error("getaddrinfo ENOTFOUND"));
+						reported.length.should.eql(2, "a new, different error was not reported");
+
+						// So is a repeat of an earlier one, once a connection has succeeded
+						// in between - that is a fresh outage, not the same one repeating.
+						broker.client.emit('connect', {});
+						broker.client.emit('error', new Error("getaddrinfo ENOTFOUND"));
+						reported.length.should.eql(3,
+							"an error after a successful reconnect was suppressed as a duplicate");
+					});
+				});
+			});
+		});
+	});
+
+	// ── Metric aliases ──────────────────────────────────────────────────────
+
+	describe('metric aliases', function () {
+
+		/**
+		 * [tck-id-payloads-alias-uniqueness] An alias MUST be unique across the
+		 * Edge Node's entire set of metrics. Two devices sharing a metric name are
+		 * still two distinct metrics.
+		 */
+		it('should give two devices distinct aliases for the same metric name', function (done) {
+			let flow = [
+				deviceNode("d1", "DeviceOne", { "temperature": { "dataType": "Int32" } }),
+				deviceNode("d2", "DeviceTwo", { "temperature": { "dataType": "Int32" } }),
+				brokerNode({ "aliasMetrics": true })
+			];
+
+			let aliases = {};
+			client = mqtt.connect(testBroker);
+			client.on('connect', function () {
+				client.subscribe("spBv1.0/Lifecycle Devices/DBIRTH/Lifecycle-EoN/+", function () {
+					helper.load(sparkplugNode, flow, {}, function () {
+						helper.getNode("d1").receive({ payload: { metrics: [{ name: "temperature", value: 1 }] } });
+						helper.getNode("d2").receive({ payload: { metrics: [{ name: "temperature", value: 2 }] } });
+					});
+				});
+			});
+
+			client.on('message', function (topic, message) {
+				let device = topic.split("/").pop();
+				let metric = metricsOf(message).find(m => m.name === "temperature");
+				if (metric) {
+					aliases[device] = typeof metric.alias === "object" ? metric.alias.toNumber() : metric.alias;
+				}
+				if (Object.keys(aliases).length === 2) {
+					check(done, function () {
+						should.exist(aliases["DeviceOne"], "DeviceOne published no alias");
+						should.exist(aliases["DeviceTwo"], "DeviceTwo published no alias");
+						aliases["DeviceOne"].should.not.eql(aliases["DeviceTwo"],
+							"both devices were given the same alias for 'temperature'");
+					});
+				}
+			});
+		});
+	});
+
+	// ── Birth timestamps ────────────────────────────────────────────────────
+
+	describe('birth timestamps', function () {
+
+		const TEMPLATE = JSON.stringify({
+			name: "LifecycleTemplate",
+			type: "Template",
+			value: {
+				version: "1.0.0",
+				isDefinition: true,
+				metrics: [{ name: "speed", type: "Int32" }],
+				parameters: []
+			}
+		});
+
+		/**
+		 * [tck-id-payloads-name-birth-data-requirement] Every metric in a birth
+		 * message carries a timestamp. Template definitions come straight from the
+		 * configuration and have none of their own.
+		 */
+		it('should stamp every metric in the NBIRTH, including template definitions', function (done) {
+			let flow = [
+				deviceNode("d1", "Device1", { "t": { "dataType": "Int32" } }),
+				brokerNode({ "templates": [TEMPLATE] })
+			];
+
+			client = mqtt.connect(testBroker);
+			client.on('connect', function () {
+				client.subscribe("spBv1.0/Lifecycle Devices/NBIRTH/Lifecycle-EoN", function () {
+					helper.load(sparkplugNode, flow, {}, function () {
+						helper.getNode("d1").receive({ payload: { metrics: [{ name: "t", value: 1 }] } });
+					});
+				});
+			});
+
+			client.on('message', function (topic, message) {
+				check(done, function () {
+					let missing = metricsOf(message).filter(m => !m.timestamp).map(m => m.name);
+					missing.should.be.empty(`NBIRTH metrics without a timestamp: ${missing.join(", ")}`);
+				});
+			});
+		});
+
+		it('should stamp every metric in the DBIRTH', function (done) {
+			let flow = [
+				deviceNode("d1", "Device1", { "a": { "dataType": "Int32" }, "b": { "dataType": "Int32" } }),
+				brokerNode()
+			];
+
+			client = mqtt.connect(testBroker);
+			client.on('connect', function () {
+				client.subscribe("spBv1.0/Lifecycle Devices/DBIRTH/Lifecycle-EoN/Device1", function () {
+					helper.load(sparkplugNode, flow, {}, function () {
+						helper.getNode("d1").receive({ payload: { metrics: [{ name: "a", value: 1 }, { name: "b", value: 2 }] } });
+					});
+				});
+			});
+
+			client.on('message', function (topic, message) {
+				check(done, function () {
+					let missing = metricsOf(message).filter(m => !m.timestamp).map(m => m.name);
+					missing.should.be.empty(`DBIRTH metrics without a timestamp: ${missing.join(", ")}`);
+				});
+			});
+		});
+	});
+
+	// ── Payload decoding ────────────────────────────────────────────────────
+
+	describe('payload decoding', function () {
+
+		/**
+		 * Sparkplug carries Int64 in an unsigned protobuf field, and
+		 * sparkplug-payload only converts it back to signed when its own `instanceof
+		 * Long` check matches - which it does not here, because protobufjs hands
+		 * back an instance of a different copy of `long`. A negative Int64 then
+		 * arrives as a huge positive number.
+		 */
+		it('should decode a negative Int64 as a negative number', function (done) {
+			let flow = [
+				{ "id": "in1", "type": "mqtt sparkplug in", "name": "", "topic": "spBv1.0/Lifecycle Devices/DDATA/#", "qos": "2", "broker": "b1", "wires": [["out1"]] },
+				{ "id": "out1", "type": "helper" },
+				brokerNode()
+			];
+
+			helper.load(sparkplugNode, flow, {}, function () {
+				let out = helper.getNode("out1");
+				let broker = helper.getNode("b1");
+				let publishing = null;
+
+				out.on("input", function (msg) {
+					clearInterval(publishing);
+					check(done, function () {
+						let metric = msg.payload.metrics.find(m => m.name === "negative");
+						should.exist(metric, "no 'negative' metric in the decoded payload");
+						let value = typeof metric.value === "object" ? metric.value.toNumber() : metric.value;
+						value.should.eql(-42, "a negative Int64 did not survive decoding");
+					});
+				});
+
+				let payload = Buffer.from(spPayload.encodePayload({
+					timestamp: Date.now(),
+					seq: 0,
+					metrics: [{ name: "negative", value: -42, type: "Int64", timestamp: Date.now() }]
+				}));
+
+				// Republish until it lands: the in node subscribes as part of connecting,
+				// so a single publish timed off our own client can beat the subscription
+				// and be dropped - which shows up as an unexplained timeout under load.
+				publishing = setInterval(function () {
+					if (broker.client && broker.connected) {
+						broker.client.publish("spBv1.0/Lifecycle Devices/DDATA/Lifecycle-EoN/Device1", payload);
+					}
+				}, 100);
+			});
+		});
+	});
+});


### PR DESCRIPTION
These issues were catalogued by the `node-red-contrib-mqtt-sparkplug-plus-wmonitor`
fork (ISC, Michael Sadowski), which branched from v2.2.4 and fixed them there. They
were re-verified and fixed independently against this code base; each one has a test
in `test/sparkplug_lifecycle_spec.js` that fails without its fix.

**Behaviour change:** the configured MQTT protocol version is now actually applied.
It was read from the broker configuration but never passed to the MQTT client, so
every connection was MQTT 3.1.1 regardless of the setting. **A configuration already
set to MQTT 5.0 will now genuinely connect as 5.0** - if the broker treats the two
differently, that changes on upgrade. With 5.0 the Edge Node also sets Clean Start
and a Session Expiry Interval of 0, so no session outlives its connection
(tck-id-principles-persistence-clean-session-50).

**Behaviour change:** metric aliases are now allocated per device rather than per
metric name. Two devices under one Edge Node that share a metric name previously
received the *same* alias, which breaks the requirement that an alias be unique
across the Edge Node's entire set of metrics (tck-id-payloads-alias-uniqueness).
Alias numbers therefore differ from previous releases; they are republished in every
birth message, so subscribers pick the new mapping up automatically.

Fixed:
- bdSeq now wraps from 255 to 0. It previously reached 256 before wrapping, one step
  outside the permitted range.
- bdSeq is taken, and the matching NDEATH re-registered as the will, for *every*
  CONNECT - including the automatic reconnects MQTT.js performs on its own.
  Previously only a deliberate connect advanced it, so every session after the first
  reused the first session's bdSeq, which
  tck-id-topics-nbirth-bdseq-increment forbids.
- bdSeq is kept in global context instead of the config node's own context, which
  Node-RED clears on redeploy. Surviving a full process restart additionally needs
  `contextStorage` configured in `settings.js`; without it behaviour is unchanged.
- The will is registered with an explicit retained flag of false
  (tck-id-message-flow-edge-node-birth-publish-will-message-will-retained).
- A negative Int64 metric no longer decodes as a huge positive number. Sparkplug
  carries Int64 in an unsigned protobuf field and `sparkplug-payload` only converts
  it back when its own `instanceof Long` check matches - which it does not, because
  protobufjs builds the value from a different copy of `long`. -42 arrived as
  18446744073709551574.
- MQTT connection errors are reported instead of being silently discarded, so a
  rejected certificate or bad credentials is visible rather than presenting as a
  connection that never comes up. Repeats of the same error are logged once, and
  reported again after a successful connection in between.
- Every metric in an NBIRTH now carries a timestamp. Template definitions come
  straight from the configuration and had none
  (tck-id-payloads-name-birth-data-requirement).
- With MQTT 5.0 the DISCONNECT sent on an intentional shutdown carries the
  'Disconnect with Will Message' reason code (0x04), so the broker publishes the will
  as well rather than discarding it
  (tck-id-payloads-ndeath-will-message-publisher-disconnect-mqtt50).
- MQTT.js no longer queues QoS 0 publishes while offline and flushes them after a
  reconnect. They arrived after the new NBIRTH had reset the sequence number, so the
  host saw the sequence jump backwards and asked for a rebirth. Replaying buffered
  data is Store Forward's job, and it replays with current sequence numbers.